### PR TITLE
fix stop() close pool.done undefined

### DIFF
--- a/utils/pool/goroutine.go
+++ b/utils/pool/goroutine.go
@@ -241,6 +241,7 @@ func NewFixedGoroutinePool(options ...fixedOption) *FixedGoroutinePool {
 	pool := &FixedGoroutinePool{
 		task:  make(chan f, defaultOptions.Num),
 		block: defaultOptions.Block,
+		done:  make(chan struct{}),
 	}
 
 	// 直接启动固定数量的协程


### PR DESCRIPTION
when test pool.Stop() is error.  
I checked pool.done is not defined, not make
